### PR TITLE
(Fixes #365) Change standard bootstrap action to use aws cli instead of hadoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.8 - 2016-04-19
+### Added
+- [#365](https://github.com/krux/hyperion/issues/365) - Change standard bootstrap action to use aws cli instead of hadoop
+
 ## 3.2.7 - 2016-04-16
 ### Added
 - [#362](https://github.com/krux/hyperion/issues/362) - Do not emit empty arrays for EmrConfiguration properties

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.7"
+val hyperionVersion = "3.2.8"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/scripts/deploy-hyperion-emr-env.sh
+++ b/scripts/deploy-hyperion-emr-env.sh
@@ -13,6 +13,6 @@ ENV_FILE="/home/hadoop/hyperion_env.sh"
 rm -f ${ENV_FILE}
 
 echo "Downloading env file from ${S3_ENV_FILE}"
-hadoop fs -get ${S3_ENV_FILE} ${ENV_FILE}
+aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
 
 echo "Done!"


### PR DESCRIPTION
Change standard bootstrap action to use aws cli instead of hadoop. 
