### PR TITLE
(Fixes #381) Adding support for emr release label in S3DistCpActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.8 - 2016-04-19
+### Added
+- [#365](https://github.com/krux/hyperion/issues/365) - Change standard bootstrap action to use aws cli instead of hadoop
+
 ## 3.2.7 - 2016-04-16
 ### Added
 - [#362](https://github.com/krux/hyperion/issues/362) - Do not emit empty arrays for EmrConfiguration properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.9 - 2016-04-20
+### Added
+- [#370](https://github.com/krux/hyperion/issues/370) - The standard bootstrap script now fails on older version of AMI (< 3.x)
+
 ## 3.2.8 - 2016-04-19
 ### Added
 - [#365](https://github.com/krux/hyperion/issues/365) - Change standard bootstrap action to use aws cli instead of hadoop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.11 - 2016-04-26
+### Changed
+- [#381](https://github.com/krux/hyperion/issues/381) - S3DistCpActivity fails when using emr-release label 4.X
+
 ## 3.2.10 - 2016-04-22
 ### Changed
 - [#376](https://github.com/krux/hyperion/issues/376) - Adds Multiple EmrConfiguration Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.10 - 2016-04-22
+### Changed
+- [#376](https://github.com/krux/hyperion/issues/376) - Adds Multiple EmrConfiguration Support
+
 ## 3.2.9 - 2016-04-20
 ### Added
 - [#370](https://github.com/krux/hyperion/issues/370) - The standard bootstrap script now fails on older version of AMI (< 3.x)

--- a/CLA.md
+++ b/CLA.md
@@ -19,7 +19,7 @@ your records.
 
 You accept and agree to the following terms and conditions for (i) UNLESS OTHERWISE
 GOVERNED BY A WRITTEN LICENSE AGREEMENT, ALL CONTRIBUTIONS THAT YOU MAY HAVE
-PREVIOUSLY SUBMITTED TO PUPPET LABS and (ii) Your present and future Contributions
+PREVIOUSLY SUBMITTED TO KRUX and (ii) Your present and future Contributions
 submitted to Krux. Except for the license granted herein to Krux
 and recipients of software distributed by Krux, You reserve all right,
 title, and interest in and to Your Contributions.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Lee Baker (bakerlee)
 Arijit Dey (arijitdey)
 Anton Winter (antonwinter)
+Peter Halliday (hoangelos)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Lee Baker (bakerlee)
 Arijit Dey (arijitdey)
+Anton Winter (antonwinter)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add hyperion as a dependency in your `build.sbt` or `Build.scala` as appropriate
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "3.2.4"
+  "com.krux" %% "hyperion" % "3.2.9"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add hyperion as a dependency in your `build.sbt` or `Build.scala` as appropriate
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "3.2.9"
+  "com.krux" %% "hyperion" % "3.2.10"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.9"
+val hyperionVersion = "3.2.10"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.10"
+val hyperionVersion = "3.2.11"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.8"
+val hyperionVersion = "3.2.9"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.7"
+val hyperionVersion = "3.2.8"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/aws/AdpResources.scala
+++ b/core/src/main/scala/com/krux/hyperion/aws/AdpResources.scala
@@ -139,7 +139,7 @@ class AdpEmrCluster(
   val httpProxy: Option[AdpRef[AdpHttpProxy]],
   val releaseLabel: Option[String],
   val applications: Option[Seq[String]],
-  val configuration: Option[AdpRef[AdpEmrConfiguration]]
+  val configuration: Option[Seq[AdpRef[AdpEmrConfiguration]]]
 ) extends AdpResource {
 
   val `type` = "EmrCluster"

--- a/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
@@ -121,8 +121,8 @@ trait EmrCluster extends ResourceObject {
   )
 
   def configuration = emrClusterFields.configuration
-  def withConfiguration(conf: EmrConfiguration): Self = updateEmrClusterFields(
-    emrClusterFields.copy(configuration = Option(conf))
+  def withConfiguration(conf: EmrConfiguration*): Self = updateEmrClusterFields(
+    emrClusterFields.copy(configuration = emrClusterFields.configuration ++ conf)
   )
 
   override def objects = configuration ++ super.objects

--- a/core/src/main/scala/com/krux/hyperion/resource/EmrClusterFields.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/EmrClusterFields.scala
@@ -24,5 +24,5 @@ case class EmrClusterFields(
   additionalSlaveSecurityGroupIds: Seq[HString] = Seq.empty,
   visibleToAllUsers: Option[HBoolean] = None,
   applications: Seq[HString] = Seq.empty,  // use with release label
-  configuration: Option[EmrConfiguration] = None
+  configuration: Seq[EmrConfiguration] = Seq.empty
 )

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
@@ -5,7 +5,6 @@ import com.krux.hyperion.Implicits._
 import com.krux.hyperion.action.SnsAlarm
 import com.krux.hyperion.activity._
 import com.krux.hyperion.common.S3Uri
-import com.krux.hyperion.datanode.S3DataNode
 import com.krux.hyperion.expression.{Format, Parameter, RuntimeNode}
 import com.krux.hyperion.resource.{MapReduceCluster}
 import com.krux.hyperion.{DataPipelineDef, HyperionContext, Schedule, _}

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflow.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflow.scala
@@ -1,0 +1,54 @@
+package com.krux.hyperion.examples
+
+import com.krux.hyperion.common.S3Uri
+import com.krux.hyperion.expression.Parameter
+import com.krux.hyperion.{DataPipelineDef, HyperionCli, HyperionContext, Schedule}
+import com.typesafe.config.ConfigFactory
+import com.krux.hyperion.Implicits._
+import com.krux.hyperion.activity.S3DistCpActivity
+import com.krux.hyperion.activity.S3DistCpActivity.OutputCodec
+import com.krux.hyperion.resource.MapReduceCluster
+
+object ExampleS3DistCpWorkflow extends DataPipelineDef with HyperionCli {
+
+  val source = "the-source"
+  val target = "the-target"
+  val jar = s3 / "sample-jars" / "sample-jar-assembly-current.jar"
+
+  override implicit val hc: HyperionContext = new HyperionContext(ConfigFactory.load("example"))
+
+  override lazy val tags = Map("example" -> None, "ownerGroup" -> Some("s3DistCP"))
+
+  override lazy val schedule = Schedule.cron
+    .startAtActivation
+    .every(1.day)
+    .stopAfter(3)
+
+  val location = Parameter[S3Uri]("S3Location").withValue(s3"your-location")
+  val instanceType = Parameter[String]("InstanceType").withValue("c3.8xlarge")
+  val instanceCount = Parameter("InstanceCount", 8)
+  val instanceBid = Parameter("InstanceBid", 3.40)
+
+  override def parameters: Iterable[Parameter[_]] = Seq(location, instanceType, instanceCount, instanceBid)
+
+  // Resources
+  val emrCluster = MapReduceCluster()
+    .withTaskInstanceCount(instanceCount)
+    .withTaskInstanceType(instanceType)
+    .withReleaseLabel("emr-4.4.0")
+    .named("Cluster with release label")
+
+  val s3DistCPActivity = S3DistCpActivity(emrCluster)
+    .named("s3DistCpActivity")
+    .withSource(
+      s3 / source
+    )
+    .withDestination(
+      s3 / target
+    )
+    .withOutputCodec(
+      OutputCodec.Gz
+    )
+
+  override def workflow = s3DistCPActivity
+}

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
@@ -1,0 +1,76 @@
+package com.krux.hyperion.examples
+
+import org.scalatest.WordSpec
+import org.json4s.JsonDSL._
+import org.json4s._
+import com.krux.hyperion.DataPipelineDef._
+
+class ExampleS3DistCpWorkflowSpec extends WordSpec {
+
+  "ExampleS3DistCpWorkflowSpec" should {
+
+    "produce correct pipeline JSON" in {
+
+      val pipelineJson: JValue = ExampleS3DistCpWorkflow
+      val objectsField = pipelineJson.children.head.children.sortBy(o => (o \ "name").toString)
+
+      // have the correct number of objects
+      assert(objectsField.size === 6)
+
+      // the first object should be Default
+      val defaultObj = objectsField(1)
+      val defaultObjShouldBe = ("id" -> "Default") ~
+        ("name" -> "Default") ~
+        ("scheduleType" -> "cron") ~
+        ("failureAndRerunMode" -> "CASCADE") ~
+        ("pipelineLogUri" -> "s3://your-bucket/datapipeline-logs/") ~
+        ("role" -> "DataPipelineDefaultRole") ~
+        ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
+        ("schedule" -> ("ref" -> "PipelineSchedule"))
+      assert(defaultObj === defaultObjShouldBe)
+
+      val pipelineSchedule = objectsField(2)
+      val pipelineScheduleShouldBe =
+        ("id" -> "PipelineSchedule") ~
+        ("name" -> "PipelineSchedule") ~
+        ("period" -> "1 days") ~
+        ("startAt" -> "FIRST_ACTIVATION_DATE_TIME") ~
+        ("occurrences" -> "3") ~
+        ("type" -> "Schedule")
+      assert(pipelineSchedule === pipelineScheduleShouldBe)
+
+      val mapReduceCluster = objectsField.head
+      val mapReduceClusterId = (mapReduceCluster \ "id").values.toString
+      assert(mapReduceClusterId.startsWith("MapReduceCluster_"))
+      val mapReduceClusterShouldBe =
+        ("id" -> mapReduceClusterId) ~
+        ("name" -> "Cluster with release label") ~
+        ("bootstrapAction" -> List("s3://your-bucket/datapipeline/scripts/deploy-hyperion-emr-env.sh,s3://bucket/org_env.sh")) ~
+        ("masterInstanceType" -> "m3.xlarge") ~
+        ("coreInstanceType" -> "m3.xlarge") ~
+        ("coreInstanceCount" -> "2") ~
+        ("taskInstanceType" -> "#{my_InstanceType}") ~
+        ("taskInstanceCount" -> "#{my_InstanceCount}") ~
+        ("terminateAfter" -> "8 hours") ~
+        ("keyPair" -> "your-aws-key-pair") ~
+        ("type" -> "EmrCluster") ~
+        ("region" -> "us-east-1") ~
+        ("role" -> "DataPipelineDefaultRole") ~
+        ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
+        ("releaseLabel" -> "emr-4.4.0")
+      assert(mapReduceCluster === mapReduceClusterShouldBe)
+
+      val s3DistCpActivity = objectsField(5)
+      val s3DistCpActivityyId = (s3DistCpActivity \ "id").values.toString
+      assert(s3DistCpActivityyId.startsWith("S3DistCpActivity_"))
+      val filterActivityShouldBe =
+        ("id" -> s3DistCpActivityyId) ~
+        ("name" -> "s3DistCpActivity") ~
+        ("runsOn" -> ("ref" -> mapReduceClusterId)) ~
+        ("step" -> List("command-runner.jar,s3-dist-cp,--src,s3://the-source,--dest,s3://the-target,--outputCodec,gz")) ~
+        ("type" -> "EmrActivity")
+      assert(s3DistCpActivity === filterActivityShouldBe)
+
+    }
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/scripts/deploy-hyperion-emr-env.sh
+++ b/scripts/deploy-hyperion-emr-env.sh
@@ -13,6 +13,11 @@ ENV_FILE="/home/hadoop/hyperion_env.sh"
 rm -f ${ENV_FILE}
 
 echo "Downloading env file from ${S3_ENV_FILE}"
-aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
+if [ -x "$(command -v aws)" ];
+then
+    aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
+else
+    hadoop fs -get ${S3_ENV_FILE} ${ENV_FILE}
+fi
 
 echo "Done!"

--- a/scripts/deploy-hyperion-emr-env.sh
+++ b/scripts/deploy-hyperion-emr-env.sh
@@ -13,6 +13,6 @@ ENV_FILE="/home/hadoop/hyperion_env.sh"
 rm -f ${ENV_FILE}
 
 echo "Downloading env file from ${S3_ENV_FILE}"
-hadoop fs -get ${S3_ENV_FILE} ${ENV_FILE}
+aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
 
 echo "Done!"


### PR DESCRIPTION
Here we check if the release label is set on the resources. If yes, we update the MapReduce to use the command-runner.jar along with s3-dist-cp command, or else use the default.
