### PR TITLE
(Fixes #475) Duplicate arguments for Hadoop Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.6.1 - 2016-11-03
+### Fixed
+- [#475](https://github.com/krux/hyperion/issues/475) - Duplicate arguments for Hadoop Activity
 
 ## 4.6.0 - 2016-10-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add Krux Hyperion as a dependency in your `build.sbt` or `Build.scala` as approp
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "4.6.0"
+  "com.krux" %% "hyperion" % "4.6.1"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.6.0"
+val hyperionVersion = "4.6.1"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
@@ -32,7 +32,7 @@ case class HadoopActivity[A <: EmrCluster] private (
   def updateActivityFields(fields: ActivityFields[A]) = copy(activityFields = fields)
   def updateEmrTaskActivityFields(fields: EmrTaskActivityFields) = copy(emrTaskActivityFields = fields)
 
-  def withArguments(arguments: HString*) = copy(arguments = arguments ++ arguments)
+  def withArguments(args: HString*) = copy(arguments = arguments ++ args)
   def withHadoopQueue(queue: HString) = copy(hadoopQueue = Option(queue))
   def withInput(input: S3DataNode*) = copy(inputs = inputs ++ input)
   def withOutput(output: S3DataNode*) = copy(outputs = outputs ++ output)

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
@@ -71,7 +71,20 @@ object ExampleMapReduce extends DataPipelineDef with HyperionCli {
         )
     )
 
-  override def workflow = filterActivity ~> scoreActivity
+  val scoreHadoopActivity = HadoopActivity(
+    jar,
+    "com.krux.hyperion.ScoreJob2"
+  )(emrCluster)
+    .named("scoreHadoopActivity")
+    .onSuccess(mailAction)
+    .withArguments(
+      target,
+      Format(SparkActivity.ScheduledStartTime - 3.days, "yyyy-MM-dd"),
+      "denormalized"
+    )
+
+
+  override def workflow = filterActivity ~> scoreActivity ~> scoreHadoopActivity
 
 }
 

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
@@ -14,7 +14,7 @@ class ExampleMapReduceSpec extends WordSpec {
       val objectsField = pipelineJson.children.head.children.sortBy(o => (o \ "name").toString)
 
       // have the correct number of objects
-      assert(objectsField.size === 6)
+      assert(objectsField.size === 7)
 
       // the first object should be Default
       val defaultObj = objectsField(1)
@@ -96,6 +96,21 @@ class ExampleMapReduceSpec extends WordSpec {
         ("onSuccess" -> List("ref" -> snsAlarmId)) ~
         ("type" -> "EmrActivity")
       assert(scoreActivity === scoreActivityShouldBe)
+
+      val scoreHadoopActivity = objectsField(6)
+      val scoreHadoopActivityId = (scoreHadoopActivity \ "id").values.toString
+      assert(scoreHadoopActivityId.startsWith("HadoopActivity_"))
+      val scoreHadoopActivityShouldBe =
+        ("id" -> scoreHadoopActivityId) ~
+        ("name" -> "scoreHadoopActivity") ~
+        ("runsOn" -> ("ref" -> mapReduceClusterId)) ~
+        ("jarUri" -> "s3://sample-jars/sample-jar-assembly-current.jar") ~
+        ("mainClass"-> "com.krux.hyperion.ScoreJob2") ~
+        ("argument" -> List("the-target", "#{format(minusDays(@scheduledStartTime,3),\"yyyy-MM-dd\")}", "denormalized")) ~
+        ("dependsOn" -> List("ref" -> scoreActivityId)) ~
+        ("onSuccess" -> List("ref" -> snsAlarmId)) ~
+        ("type" -> "HadoopActivity")
+      assert(scoreHadoopActivity === scoreHadoopActivityShouldBe)
 
     }
   }


### PR DESCRIPTION
The Hadoop activity used to add arguments twice. Adding a fix to add
arguments only once.