### PR TITLE
(Fixes #477) Make `initTimeout` as a optional global configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.6.1 - 2016-11-03
+### Fixed
+- [#475](https://github.com/krux/hyperion/issues/475) - Duplicate arguments for Hadoop Activity
 
 ## 4.6.0 - 2016-10-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.6.2 - 2016-12-07
+### Fixed
+- [#477](https://github.com/krux/hyperion/issues/477) - Make `initTimeout` as a optional global configuration
+
 ## 4.6.1 - 2016-11-03
 ### Fixed
 - [#475](https://github.com/krux/hyperion/issues/475) - Duplicate arguments for Hadoop Activity

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add Krux Hyperion as a dependency in your `build.sbt` or `Build.scala` as approp
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "4.6.0"
+  "com.krux" %% "hyperion" % "4.6.1"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add Krux Hyperion as a dependency in your `build.sbt` or `Build.scala` as approp
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "4.6.1"
+  "com.krux" %% "hyperion" % "4.6.2"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.6.0"
+val hyperionVersion = "4.6.1"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.10.43"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.6.1"
+val hyperionVersion = "4.6.2"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/HyperionContext.scala
+++ b/core/src/main/scala/com/krux/hyperion/HyperionContext.scala
@@ -57,6 +57,7 @@ class HyperionContext(config: Config) {
   lazy val emrEnvironmentUri = Try(config.getString("hyperion.aws.emr.env.uri")).toOption
   lazy val emrTerminateAfter = Try(config.getString("hyperion.aws.emr.terminate")).toOption.map(Duration(_))
   lazy val emrSparkVersion = Try(config.getString("hyperion.aws.emr.spark.version")).toOption
+  lazy val emrInitTimeout = Try(config.getString("hyperion.aws.emr.inittimeout")).toOption.map(Duration(_))
 
   //
   // SNS default configuration

--- a/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
@@ -32,7 +32,7 @@ case class HadoopActivity[A <: EmrCluster] private (
   def updateActivityFields(fields: ActivityFields[A]) = copy(activityFields = fields)
   def updateEmrTaskActivityFields(fields: EmrTaskActivityFields) = copy(emrTaskActivityFields = fields)
 
-  def withArguments(arguments: HString*) = copy(arguments = arguments ++ arguments)
+  def withArguments(args: HString*) = copy(arguments = arguments ++ args)
   def withHadoopQueue(queue: HString) = copy(hadoopQueue = Option(queue))
   def withInput(input: S3DataNode*) = copy(inputs = inputs ++ input)
   def withOutput(output: S3DataNode*) = copy(outputs = outputs ++ output)

--- a/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
@@ -209,7 +209,8 @@ object EmrCluster {
     resourceRole = Option(hc.emrResourceRole: HString),
     role = Option(hc.emrRole: HString),
     subnetId = hc.emrSubnetId.map(x => x: HString),
-    terminateAfter = hc.emrTerminateAfter.map(x => x: HDuration)
+    terminateAfter = hc.emrTerminateAfter.map(x => x: HDuration),
+    initTimeout = hc.emrInitTimeout.map(x => x: HDuration)
   )
 
 }

--- a/examples/src/main/resources/example.conf
+++ b/examples/src/main/resources/example.conf
@@ -18,6 +18,7 @@ hyperion {
             terminate = "8 hours"
             spark.version = "1.1.1.e"
             env.uri = "s3://bucket/org_env.sh"
+            inittimeout = "1 hours"
         }
     }
 }

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
@@ -71,7 +71,20 @@ object ExampleMapReduce extends DataPipelineDef with HyperionCli {
         )
     )
 
-  override def workflow = filterActivity ~> scoreActivity
+  val scoreHadoopActivity = HadoopActivity(
+    jar,
+    "com.krux.hyperion.ScoreJob2"
+  )(emrCluster)
+    .named("scoreHadoopActivity")
+    .onSuccess(mailAction)
+    .withArguments(
+      target,
+      Format(SparkActivity.ScheduledStartTime - 3.days, "yyyy-MM-dd"),
+      "denormalized"
+    )
+
+
+  override def workflow = filterActivity ~> scoreActivity ~> scoreHadoopActivity
 
 }
 

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleSpark.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleSpark.scala
@@ -45,6 +45,7 @@ object ExampleSpark extends DataPipelineDef with HyperionCli {
   val sparkCluster = SparkCluster()
     .withTaskInstanceCount(instanceCount)
     .withTaskInstanceType(instanceType)
+    .withInitTimeout(5.hours)
 
   // First activity
   val filterActivity = SparkTaskActivity(jar.toString, "com.krux.hyperion.FilterJob")(sparkCluster)

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleHiveActivitySpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleHiveActivitySpec.scala
@@ -40,7 +40,8 @@ class ExampleHiveActivitySpec extends WordSpec {
           ("region" -> "us-east-1") ~
           ("role" -> "DataPipelineDefaultRole") ~
           ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
-          ("releaseLabel" -> "emr-4.4.0")
+          ("releaseLabel" -> "emr-4.4.0") ~
+          ("initTimeout" -> "1 hours")
       assert(mapReduceCluster === mapReduceClusterShouldBe)
 
       val pipelineSchedule = objectsField(3)

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
@@ -69,7 +69,8 @@ class ExampleMapReduceSpec extends WordSpec {
         ("region" -> "us-east-1") ~
         ("role" -> "DataPipelineDefaultRole") ~
         ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
-        ("releaseLabel" -> "emr-4.4.0")
+        ("releaseLabel" -> "emr-4.4.0") ~
+        ("initTimeout" -> "1 hours")
       assert(mapReduceCluster === mapReduceClusterShouldBe)
 
       val filterActivity = objectsField(4)

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
@@ -14,7 +14,7 @@ class ExampleMapReduceSpec extends WordSpec {
       val objectsField = pipelineJson.children.head.children.sortBy(o => (o \ "name").toString)
 
       // have the correct number of objects
-      assert(objectsField.size === 6)
+      assert(objectsField.size === 7)
 
       // the first object should be Default
       val defaultObj = objectsField(1)
@@ -96,6 +96,21 @@ class ExampleMapReduceSpec extends WordSpec {
         ("onSuccess" -> List("ref" -> snsAlarmId)) ~
         ("type" -> "EmrActivity")
       assert(scoreActivity === scoreActivityShouldBe)
+
+      val scoreHadoopActivity = objectsField(6)
+      val scoreHadoopActivityId = (scoreHadoopActivity \ "id").values.toString
+      assert(scoreHadoopActivityId.startsWith("HadoopActivity_"))
+      val scoreHadoopActivityShouldBe =
+        ("id" -> scoreHadoopActivityId) ~
+        ("name" -> "scoreHadoopActivity") ~
+        ("runsOn" -> ("ref" -> mapReduceClusterId)) ~
+        ("jarUri" -> "s3://sample-jars/sample-jar-assembly-current.jar") ~
+        ("mainClass"-> "com.krux.hyperion.ScoreJob2") ~
+        ("argument" -> List("the-target", "#{format(minusDays(@scheduledStartTime,3),\"yyyy-MM-dd\")}", "denormalized")) ~
+        ("dependsOn" -> List("ref" -> scoreActivityId)) ~
+        ("onSuccess" -> List("ref" -> snsAlarmId)) ~
+        ("type" -> "HadoopActivity")
+      assert(scoreHadoopActivity === scoreHadoopActivityShouldBe)
 
     }
   }

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
@@ -56,7 +56,8 @@ class ExampleS3DistCpWorkflowSpec extends WordSpec {
         ("region" -> "us-east-1") ~
         ("role" -> "DataPipelineDefaultRole") ~
         ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
-        ("releaseLabel" -> "emr-4.4.0")
+        ("releaseLabel" -> "emr-4.4.0") ~
+        ("initTimeout" -> "1 hours")
       assert(mapReduceCluster === mapReduceClusterShouldBe)
 
       val s3DistCpActivity = objectsField(3)

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleSparkSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleSparkSpec.scala
@@ -79,7 +79,8 @@ class ExampleSparkSpec extends WordSpec {
         ("type" -> "EmrCluster") ~
         ("region" -> "us-east-1") ~
         ("role" -> "DataPipelineDefaultRole") ~
-        ("resourceRole" -> "DataPipelineDefaultResourceRole")
+        ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
+        ("initTimeout" -> "5 hours")
       assert(sparkCluster === sparkClusterShouldBe)
 
       val filterActivity = objectsField(5)


### PR DESCRIPTION
Adding ability to read the `initTimeout` from a global configuration
file. It can also be set for a resource using
`.withInitTimeout(5.hours)`.