### PR TITLE
(Fixes #487) Update GoogleStorageUploadActivity to allow recursive copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.10.1 - 2017-03-09
+### Chnanged
+- [#487](https://github.com/krux/hyperion/issues/487) - Update GoogleStorageUploadActivity to allow recursive copy
+
 ## 4.10.0 - 2017-02-23
 ### Chnanged
 - [#484](https://github.com/krux/hyperion/issues/484) - Update to use AWS SDK to 1.11.93

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add Krux Hyperion as a dependency in your `build.sbt` or `Build.scala` as approp
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "4.9.1"
+  "com.krux" %% "hyperion" % "4.10.1"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.10.0"
+val hyperionVersion = "4.10.1"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.11.93"

--- a/scripts/activities/gsutil-upload.sh
+++ b/scripts/activities/gsutil-upload.sh
@@ -69,5 +69,5 @@ if [ "${NUM_INPUT_FILES}" -eq "0" ]; then
   exit 3
 fi
 
-./gsutil/gsutil cp ${INPUT1_STAGING_DIR}/* ${OUTPUT_GOOGLE_STORAGE}
+./gsutil/gsutil -m cp -r ${INPUT1_STAGING_DIR}/* ${OUTPUT_GOOGLE_STORAGE}
 


### PR DESCRIPTION
This update allows us to copy directories containing multiple files or
directories along with single objects.